### PR TITLE
Compatibility with symfony/yaml 3.x

### DIFF
--- a/tests/UAParser/Tests/BrowserParserTest.php
+++ b/tests/UAParser/Tests/BrowserParserTest.php
@@ -32,6 +32,6 @@ class BrowserParserTest extends \PHPUnit_Framework_TestCase
 
     public function browserDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/browsers.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/browsers.yml'));
     }
 }

--- a/tests/UAParser/Tests/DeviceParserTest.php
+++ b/tests/UAParser/Tests/DeviceParserTest.php
@@ -31,6 +31,6 @@ class DeviceParserTest extends \PHPUnit_Framework_TestCase
 
     public function deviceDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/devices.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/devices.yml'));
     }
 }

--- a/tests/UAParser/Tests/EmailClientParserTest.php
+++ b/tests/UAParser/Tests/EmailClientParserTest.php
@@ -33,7 +33,7 @@ class EmailClientParserTest extends \PHPUnit_Framework_TestCase
 
     public function emailClientDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/email_clients.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/email_clients.yml'));
     }
         
     /**
@@ -49,6 +49,6 @@ class EmailClientParserTest extends \PHPUnit_Framework_TestCase
 
     public function emailClientRefererDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/referers.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/referers.yml'));
     }
 }

--- a/tests/UAParser/Tests/OperatingSystemParserTest.php
+++ b/tests/UAParser/Tests/OperatingSystemParserTest.php
@@ -32,6 +32,6 @@ class OperatingSystemParserTest extends \PHPUnit_Framework_TestCase
 
     public function operatingSystemDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/operating_systems.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/operating_systems.yml'));
     }
 }

--- a/tests/UAParser/Tests/RenderingEngineParserTest.php
+++ b/tests/UAParser/Tests/RenderingEngineParserTest.php
@@ -30,6 +30,6 @@ class RenderingEngineParserTest extends \PHPUnit_Framework_TestCase
 
     public function renderingEngineDataProvider()
     {
-        return Yaml::parse(__DIR__.'/Fixtures/rendering_engines.yml');
+        return Yaml::parse(file_get_contents(__DIR__.'/Fixtures/rendering_engines.yml'));
     }
 }


### PR DESCRIPTION
Passing a filename to Yaml::parse() is deprecated in Symfony 2.2, and was removed in
Symfony 3.0.