### PR TITLE
PHP 7.3 Compatibility and PHP 5.5 travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
     - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - 7.3
 
 before_script:
     - composer install --prefer-source

--- a/regexes.yml
+++ b/regexes.yml
@@ -47,7 +47,7 @@ device_parsers:
       constructor_replacement: Apple
       model_replacement: $1
       type_replacement: mobile
-    - regex: '(lg)[e;\s-\/]+(\w+)*'
+    - regex: '(lg)[e;\s\-\/]+(\w+)*'
       constructor_replacement: LG
       model_replacement: $2
       type_replacement: mobile


### PR DESCRIPTION
Hi, I made the following changes that I needed when moving a project to PHP 7.3:

1. Made reg exes php7.3 (i.e. PRCE2) compatible
2. added php 7.2 and php 7.3 to travis
3. added distro trusty to travis as it seems that php 5.5 was not supported anymore: https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723/3
